### PR TITLE
fix(clippy): Change the error type of `Address::try_cast()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "primordial"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nathaniel McCallum <npmccallum@redhat.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/address.rs
+++ b/src/address.rs
@@ -48,6 +48,8 @@ impl<T, U> Address<T, U> {
     }
 }
 
+pub struct AlignmentError;
+
 impl<T, U> Address<T, U>
 where
     Offset<usize, ()>: Into<Offset<T, ()>>,
@@ -59,10 +61,10 @@ where
     ///
     /// Succeeds only, if they have the same alignment
     #[inline]
-    pub fn try_cast<V>(self) -> Result<Address<T, V>, ()> {
+    pub fn try_cast<V>(self) -> Result<Address<T, V>, AlignmentError> {
         let align: T = Offset::from_items(align_of::<V>()).into().items();
         if self.0 % align != T::ZERO {
-            return Err(());
+            return Err(AlignmentError);
         }
         Ok(Address(self.0, PhantomData))
     }


### PR DESCRIPTION
Clippy complains, that the error type is unit.

https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err

BREAKING CHANGE: Changes the return value of `Address::try_cast()`

Fixes: https://github.com/enarx/primordial/issues/3

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
