### PR TITLE
fix: implement Debug like Display

### DIFF
--- a/src/offset.rs
+++ b/src/offset.rs
@@ -15,9 +15,15 @@ use core::ops::*;
 /// underlying types so long as the conversion is lossless for the target CPU
 /// architecture. For example, `Offset<u64>` can be converted to
 /// `Offset<usize>` on 64-bit systems.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default)]
 #[repr(transparent)]
 pub struct Offset<T, U>(T, PhantomData<U>);
+
+impl<T: core::fmt::Debug, U> core::fmt::Debug for Offset<T, U> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.0, f)
+    }
+}
 
 impl<T: core::fmt::Binary, U> core::fmt::Binary for Offset<T, U> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
If `PhantomData<U>` does not implement Debug, the `Offset<T, U>` does not
implement Debug, although T might implement Debug.

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
